### PR TITLE
Added MaterialPathResolver as a fallback for GameInfoFile

### DIFF
--- a/BlenderMaterial.py
+++ b/BlenderMaterial.py
@@ -25,15 +25,44 @@ class BlenderMaterial:
                 if image:
                     self.textures[key] = image
 
+    def find_material_case_insensitive(self, material_name):
+        for mat in bpy.data.materials.items():
+            if mat[0].lower() == material_name.lower():
+                print('Material matched case-insensitively')
+                return mat[1]
+        return None
+
     def create_material(self, override=True):
         mat_name = self.vmt.filepath.stem
-        if bpy.data.materials.get(mat_name) and not override:
+        if bpy.data.materials.get(mat_name) or self.find_material_case_insensitive(mat_name) and not override:
             return 'EXISTS'
-        bpy.data.materials.new(mat_name)
+
         mat = bpy.data.materials.get(mat_name)
+        print("Loading mat:" + mat_name)
+        if not mat:
+            print("Attempting to resolve materials case-insensitively")
+            mat = self.find_material_case_insensitive(mat_name)
+
+        if not mat:
+            print("Material not found, create a new one")
+            bpy.data.materials.new(mat_name)
+            mat = bpy.data.materials.get(mat_name)
+
+        print('Assigning textures to material')
+
         mat.use_nodes = True
         nodes = mat.node_tree.nodes
-        nodes.remove(nodes.get('Diffuse BSDF', None))
+
+        # remove the default node for 2.80
+        default_node = nodes.get('Principled BSDF', None)
+        if default_node is not None:
+            nodes.remove(default_node)
+        else:
+            # default node is Diffuse in Blender 2.79
+            default_node = nodes.get('Diffuse BSDF', None)
+            if default_node is not None:
+                nodes.remove(default_node)
+
         out = nodes.get('ShaderNodeOutputMaterial', None)
         if not out:
             out = nodes.get('Material Output',None)

--- a/VMT.py
+++ b/VMT.py
@@ -2,9 +2,9 @@ import os
 from pprint import pprint
 
 try:
-    from ValveUtils import KeyValueFile, GameInfoFile
+    from ValveUtils import KeyValueFile, GameInfoFile, MaterialPathResolver
 except:
-    from .ValveUtils import KeyValueFile, GameInfoFile
+    from .ValveUtils import KeyValueFile, GameInfoFile, MaterialPathResolver
 from pathlib import Path
 if os.environ.get('VProject',None):
     del os.environ['VProject']
@@ -27,7 +27,14 @@ class VMT:
         self.kv = KeyValueFile(filepath=filepath)
         self.shader = self.kv.root_chunk.key
         self.material_data = self.kv.as_dict[self.shader]
-        self.gameinfo = GameInfoFile(game_dir / 'gameinfo.txt')
+        gameinfo_path =  game_dir / 'gameinfo.txt'
+        if os.path.isfile(gameinfo_path):
+            self.gameinfo = GameInfoFile(gameinfo_path)
+        else:
+            # We might not be dealing with a Source installation.
+            # Use material path instead
+            self.gameinfo = MaterialPathResolver(game_dir)
+
 
     def parse(self):
         print(self.shader)

--- a/ValveUtils.py
+++ b/ValveUtils.py
@@ -757,3 +757,44 @@ class GameInfoException(Exception):
         Exception.__init__(self, message)
         self.errno = None
         self.strerror = message
+
+
+class MaterialPathResolver():
+    '''
+    "Best Effort" material resolver for use when
+    no Source games are installed, or files are
+    not installed in a Source mod directory
+    '''
+    def __init__(self, filepath):
+        self.filepath = filepath
+
+    @property
+    def filepath(self):
+        return self._filepath
+
+    @filepath.setter
+    def filepath(self, new_filepath):
+        """
+        this wrapper is here so to ensure the _filepath attribute is a ValvePath instance
+        """
+        if type(new_filepath) is not Path:
+            self._filepath = Path(new_filepath)
+        else:
+            self._filepath = new_filepath
+
+    def find_texture(self, filepath):
+        return self.find_file(filepath, 'materials', extention='.vtf')
+
+    def find_file(self, filepath: str, additional_dir=None, extention=None):
+        if additional_dir:
+            new_filepath = self.filepath / additional_dir / filepath
+        else:
+            new_filepath = self.filepath / filepath
+
+        if extention:
+            new_filepath = new_filepath.with_suffix(extention)
+
+        if new_filepath.exists():
+            return new_filepath
+
+        return None


### PR DESCRIPTION
`MaterialPathResolver` acts as an alternative to `GameInfoFile`. While `GameInfoFile` works well for Source engine development, we can not assume that all imported files are in a Source game/mod
directory, while we can still assume material path structure.

Example use-cases include models and materials folders downloaded from SFMLab, extracted Garry's Mod gma archives. Especially relevant on platforms where few or no Source games are supported natively, and a GameInfo.txt is rarely available. (Linux, macOS)

In addition, the Source engine's inability to deal with case-sensitive filesystems bites me in the ass once more. :cry: I added the option that tries to resolve vmt material names case-insensitively in case we are overriding existing materials. I noticed that the materials created by the MDL importer often differ from VMT names.

Edit: please note that I was unable to test the existing `GameInfoFile` functionality, so please test before merging. <3